### PR TITLE
Remove public keyword from extensions methods.

### DIFF
--- a/GenericJSON/Querying.swift
+++ b/GenericJSON/Querying.swift
@@ -3,7 +3,7 @@ import Foundation
 public extension JSON {
 
     /// Return the string value if this is a `.string`, otherwise `nil`
-    public var stringValue: String? {
+    var stringValue: String? {
         if case .string(let value) = self {
             return value
         }
@@ -11,7 +11,7 @@ public extension JSON {
     }
 
     /// Return the float value if this is a `.number`, otherwise `nil`
-    public var floatValue: Float? {
+    var floatValue: Float? {
         if case .number(let value) = self {
             return value
         }
@@ -19,7 +19,7 @@ public extension JSON {
     }
 
     /// Return the bool value if this is a `.bool`, otherwise `nil`
-    public var boolValue: Bool? {
+    var boolValue: Bool? {
         if case .bool(let value) = self {
             return value
         }
@@ -27,7 +27,7 @@ public extension JSON {
     }
 
     /// Return the object value if this is an `.object`, otherwise `nil`
-    public var objectValue: [String: JSON]? {
+    var objectValue: [String: JSON]? {
         if case .object(let value) = self {
             return value
         }
@@ -35,7 +35,7 @@ public extension JSON {
     }
 
     /// Return the array value if this is an `.array`, otherwise `nil`
-    public var arrayValue: [JSON]? {
+    var arrayValue: [JSON]? {
         if case .array(let value) = self {
             return value
         }
@@ -43,7 +43,7 @@ public extension JSON {
     }
 
     /// Return `true` iff this is `.null`
-    public var isNull: Bool {
+    var isNull: Bool {
         if case .null = self {
             return true
         }
@@ -53,7 +53,7 @@ public extension JSON {
     /// If this is an `.array`, return item at index
     ///
     /// If this is not an `.array` or the index is out of bounds, returns `nil`.
-    public subscript(index: Int) -> JSON? {
+    subscript(index: Int) -> JSON? {
         if case .array(let arr) = self, arr.indices.contains(index) {
             return arr[index]
         }
@@ -61,7 +61,7 @@ public extension JSON {
     }
 
     /// If this is an `.object`, return item at key
-    public subscript(key: String) -> JSON? {
+    subscript(key: String) -> JSON? {
         if case .object(let dict) = self {
             return dict[key]
         }
@@ -78,7 +78,7 @@ public extension JSON {
     /// Return the JSON type at the keypath if this is an `.object`, otherwise `nil`
     ///
     /// This lets you write `json[keyPath: "foo.bar.jar"]`.
-    public subscript(keyPath keyPath: String) -> JSON? {
+    subscript(keyPath keyPath: String) -> JSON? {
         return queryKeyPath(keyPath.components(separatedBy: "."))
     }
     


### PR DESCRIPTION
In Xcode 10.2, use of `public` in extensions generates an error `'public' modifier is redundant for property declared in a public extension`.