### PR TITLE
implemented set subscripts

### DIFF
--- a/GenericJSON.xcodeproj/project.pbxproj
+++ b/GenericJSON.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		0D8B1C881F5011130071F6FC /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D8B1C871F5011130071F6FC /* JSON.swift */; };
 		0D8B1C8A1F50113F0071F6FC /* Initialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D8B1C891F50113F0071F6FC /* Initialization.swift */; };
 		0D8B1C8E1F5013DB0071F6FC /* EqualityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D8B1C8D1F5013DB0071F6FC /* EqualityTests.swift */; };
+		D932B8C8226E0EC50024B3BC /* EditingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D932B8C7226E0EC50024B3BC /* EditingTests.swift */; };
 		FC5111AD2180B8E200D335C5 /* QueryingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5111AC2180B8E100D335C5 /* QueryingTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -44,6 +45,7 @@
 		0DB7DD181F50285E00539475 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0DB7DD1D1F5028E600539475 /* Playground.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = Playground.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		0DDB78691F505F77007BC950 /* InitializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitializationTests.swift; sourceTree = "<group>"; };
+		D932B8C7226E0EC50024B3BC /* EditingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditingTests.swift; sourceTree = "<group>"; };
 		FC5111AC2180B8E100D335C5 /* QueryingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryingTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -104,6 +106,7 @@
 				FC5111AC2180B8E100D335C5 /* QueryingTests.swift */,
 				0D8B1C7B1F5011010071F6FC /* CodingTests.swift */,
 				0DDB78691F505F77007BC950 /* InitializationTests.swift */,
+				D932B8C7226E0EC50024B3BC /* EditingTests.swift */,
 				0D8B1C8D1F5013DB0071F6FC /* EqualityTests.swift */,
 				0D7AB1C021A3F6EF006333EF /* MergingTests.swift */,
 				0D8B1C7D1F5011010071F6FC /* Info.plist */,
@@ -242,6 +245,7 @@
 			files = (
 				FC5111AD2180B8E200D335C5 /* QueryingTests.swift in Sources */,
 				0D8B1C7C1F5011010071F6FC /* CodingTests.swift in Sources */,
+				D932B8C8226E0EC50024B3BC /* EditingTests.swift in Sources */,
 				0D25132320E732CA0079E170 /* InitializationTests.swift in Sources */,
 				0D8B1C8E1F5013DB0071F6FC /* EqualityTests.swift in Sources */,
 				0D7AB1C121A3F6EF006333EF /* MergingTests.swift in Sources */,

--- a/GenericJSON/Querying.swift
+++ b/GenericJSON/Querying.swift
@@ -50,58 +50,83 @@ public extension JSON {
         return false
     }
 
-    /// If this is an `.array`, return item at index
+    /// If this is an `.array`, returns or sets the item at index
     ///
     /// If this is not an `.array` or the index is out of bounds, returns `nil`.
     subscript(index: Int) -> JSON? {
-        if case .array(let arr) = self, arr.indices.contains(index) {
-            return arr[index]
+        get {
+            if case .array(let arr) = self, arr.indices.contains(index) {
+                return arr[index]
+            }
+            return nil
         }
-        return nil
+        set {
+            if case .array(var arr) = self, arr.indices.contains(index) {
+                if let value = newValue {
+                    arr[index] = value
+                } else {
+                    arr[index] = .null
+                }
+                self = .array(arr)
+            }
+        }
     }
 
-    /// If this is an `.object`, return item at key
+    /// If this is an `.object`, returns or sets the item at key
     subscript(key: String) -> JSON? {
-        if case .object(let dict) = self {
-            return dict[key]
+        get {
+            if case .object(let dict) = self {
+                return dict[key]
+            }
+            return nil
         }
-        return nil
+        set {
+            if case .object(var dict) = self {
+                dict[key] = newValue
+                self = .object(dict)
+            }
+        }
     }
 
     /// Dynamic member lookup sugar for string subscripts
     ///
     /// This lets you write `json.foo` instead of `json["foo"]`.
     subscript(dynamicMember member: String) -> JSON? {
-        return self[member]
+        get {
+            return self[member]
+        }
+        set {
+            self[member] = newValue
+        }
     }
-    
+
     /// Return the JSON type at the keypath if this is an `.object`, otherwise `nil`
     ///
     /// This lets you write `json[keyPath: "foo.bar.jar"]`.
     subscript(keyPath keyPath: String) -> JSON? {
         return queryKeyPath(keyPath.components(separatedBy: "."))
     }
-    
+
     func queryKeyPath<T>(_ path: T) -> JSON? where T: Collection, T.Element == String {
-        
+
         // Only object values may be subscripted
         guard case .object(let object) = self else {
             return nil
         }
-        
+
         // Is the path non-empty?
         guard let head = path.first else {
             return nil
         }
-        
+
         // Do we have a value at the required key?
         guard let value = object[head] else {
             return nil
         }
-        
+
         let tail = path.dropFirst()
-        
+
         return tail.isEmpty ? value : value.queryKeyPath(tail)
     }
-    
+
 }

--- a/GenericJSONTests/EditingTests.swift
+++ b/GenericJSONTests/EditingTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import GenericJSON
+
+class EditingTests: XCTestCase {
+
+    func testArrayEditing() throws {
+        var json = try JSON([1, 2, 3])
+        json[1] = 5
+        XCTAssertEqual(json[1], 5)
+        json[2] = ["json": 0, "test": 1]
+        XCTAssertEqual(json[2]?.test, 1)
+    }
+
+    func testObjectEditing() throws {
+        var json = try JSON([
+            "a": [1, 2],
+            "b": ["A", true, 1],
+            ])
+        json["a"] = 0
+        XCTAssertEqual(json.a, 0)
+        json["b"] = nil
+        XCTAssertFalse((json.objectValue?.keys.contains("b"))!)
+        json["b"] = JSON.null
+        XCTAssertEqual(json.b, .null)
+    }
+
+    func testDynamicMemberEditing() throws {
+        var json = try JSON([
+            "test": [
+                "a": "A",
+                "b": true,
+                "c": 1],
+            ])
+        json.test?.b = false
+        XCTAssertFalse(json.test!.b!.boolValue!)
+        json.test?.d = [1,2,3]
+        XCTAssertNotNil(json.test?.d?.arrayValue)
+    }
+}


### PR DESCRIPTION
Currently it is quite difficult to edit a JSON value once created, for example you cannot write
```
var json = ["a" : 1, "b" : 1]
json.b = 5
```
I've implemented set accessors to the three main subscripts in Querying.swift, so it will be possible to edit JSON values on-the-fly.
I've also included a related test file to provide some working examples.