### PR TITLE
Fix: Double number type

### DIFF
--- a/GenericJSON/Initialization.swift
+++ b/GenericJSON/Initialization.swift
@@ -16,10 +16,10 @@ extension JSON {
             self = .null
         case let opt as Optional<Any> where opt == nil:
             self = .null
-        case let num as Float:
+        case let num as Double:
             self = .number(num)
         case let num as Int:
-            self = .number(Float(num))
+            self = .number(Double(num))
         case let str as String:
             self = .string(str)
         case let bool as Bool:
@@ -78,7 +78,7 @@ extension JSON: ExpressibleByDictionaryLiteral {
 
 extension JSON: ExpressibleByFloatLiteral {
 
-    public init(floatLiteral value: Float) {
+    public init(floatLiteral value: Double) {
         self = .number(value)
     }
 }
@@ -86,7 +86,7 @@ extension JSON: ExpressibleByFloatLiteral {
 extension JSON: ExpressibleByIntegerLiteral {
 
     public init(integerLiteral value: Int) {
-        self = .number(Float(value))
+        self = .number(Double(value))
     }
 }
 

--- a/GenericJSON/JSON.swift
+++ b/GenericJSON/JSON.swift
@@ -6,7 +6,7 @@ import Foundation
 /// or strings.
 @dynamicMemberLookup public enum JSON: Equatable {
     case string(String)
-    case number(Float)
+    case number(Double)
     case object([String:JSON])
     case array([JSON])
     case bool(Bool)
@@ -47,7 +47,7 @@ extension JSON: Codable {
             self = .string(string)
         } else if let bool = try? container.decode(Bool.self) {
             self = .bool(bool)
-        } else if let number = try? container.decode(Float.self) {
+        } else if let number = try? container.decode(Double.self) {
             self = .number(number)
         } else if container.decodeNil() {
             self = .null

--- a/GenericJSON/Querying.swift
+++ b/GenericJSON/Querying.swift
@@ -10,8 +10,8 @@ public extension JSON {
         return nil
     }
 
-    /// Return the float value if this is a `.number`, otherwise `nil`
-    var floatValue: Float? {
+    /// Return the double value if this is a `.number`, otherwise `nil`
+    var doubleValue: Double? {
         if case .number(let value) = self {
             return value
         }

--- a/GenericJSONTests/InitializationTests.swift
+++ b/GenericJSONTests/InitializationTests.swift
@@ -8,7 +8,7 @@ class InitializationTests: XCTestCase {
         XCTAssertEqual(true as JSON, .bool(true))
         XCTAssertEqual([1, 2] as JSON, .array([.number(1), .number(2)]))
         XCTAssertEqual(["x": 1] as JSON, .object(["x": .number(1)]))
-        XCTAssertEqual(1.25 as JSON, .number(1.25))
+        XCTAssertEqual(3.4028236e+38 as JSON, .number(3.4028236e+38))
         XCTAssertEqual("foo" as JSON, .string("foo"))
     }
 

--- a/GenericJSONTests/QueryingTests.swift
+++ b/GenericJSONTests/QueryingTests.swift
@@ -10,9 +10,9 @@ class QueryingTests: XCTestCase {
     }
 
     func testFloatValue() {
-        XCTAssertEqual(JSON.number(42).floatValue, 42)
-        XCTAssertEqual(JSON.string("foo").floatValue, nil)
-        XCTAssertEqual(JSON.null.floatValue, nil)
+        XCTAssertEqual(JSON.number(42).doubleValue, 42)
+        XCTAssertEqual(JSON.string("foo").doubleValue, nil)
+        XCTAssertEqual(JSON.null.doubleValue, nil)
     }
 
     func testBoolValue() {


### PR DESCRIPTION
This PR updates `JSON`'s internal enum case `number` to be associated with a value of type `Double` (instead of `Float`). This allows `JSON` to handle 64-bit floating point values.

The next step is to explore using `NSNumber` as a matching case during init to solve the issues in [28](https://github.com/zoul/generic-json-swift/issues/28).