### PR TITLE
Add NSNumber initialization & Double number

### DIFF
--- a/GenericJSON/Initialization.swift
+++ b/GenericJSON/Initialization.swift
@@ -16,10 +16,12 @@ extension JSON {
             self = .null
         case let opt as Optional<Any> where opt == nil:
             self = .null
-        case let num as Double:
-            self = .number(num)
-        case let num as Int:
-            self = .number(Double(num))
+        case let num as NSNumber:
+            if num.isBool {
+                self = .bool(num.boolValue)
+            } else {
+                self = .number(num.doubleValue)
+            }
         case let str as String:
             self = .string(str)
         case let bool as Bool:
@@ -96,3 +98,21 @@ extension JSON: ExpressibleByStringLiteral {
         self = .string(value)
     }
 }
+
+// MARK: - NSNumber
+
+extension NSNumber {
+    fileprivate var isBool: Bool {
+        let objCType = String(cString: self.objCType)
+        if (self.compare(trueNumber) == .orderedSame && objCType == trueObjCType) || (self.compare(falseNumber) == .orderedSame && objCType == falseObjCType) {
+            return true
+        } else {
+            return false
+        }
+    }
+}
+
+private let trueNumber = NSNumber(value: true)
+private let falseNumber = NSNumber(value: false)
+private let trueObjCType = String(cString: trueNumber.objCType)
+private let falseObjCType = String(cString: falseNumber.objCType)

--- a/GenericJSON/Initialization.swift
+++ b/GenericJSON/Initialization.swift
@@ -6,7 +6,7 @@ extension JSON {
 
     /// Create a JSON value from anything.
     ///
-    /// Argument has to be a valid JSON structure: A `Float`, `Int`, `String`,
+    /// Argument has to be a valid JSON structure: A `Double`, `Int`, `String`,
     /// `Bool`, an `Array` of those types or a `Dictionary` of those types.
     ///
     /// You can also pass `nil` or `NSNull`, both will be treated as `.null`.
@@ -102,6 +102,12 @@ extension JSON: ExpressibleByStringLiteral {
 // MARK: - NSNumber
 
 extension NSNumber {
+
+    /// Boolean value indicating whether this `NSNumber` wraps a boolean.
+    ///
+    /// For example, when using `NSJSONSerialization` Bool values are converted into `NSNumber` instances.
+    ///
+    /// - seealso: https://stackoverflow.com/a/49641315/3589408
     fileprivate var isBool: Bool {
         let objCType = String(cString: self.objCType)
         if (self.compare(trueNumber) == .orderedSame && objCType == trueObjCType) || (self.compare(falseNumber) == .orderedSame && objCType == falseObjCType) {

--- a/GenericJSON/Initialization.swift
+++ b/GenericJSON/Initialization.swift
@@ -16,10 +16,10 @@ extension JSON {
             self = .null
         case let opt as Optional<Any> where opt == nil:
             self = .null
-        case let num as Float:
+        case let num as Double:
             self = .number(num)
         case let num as Int:
-            self = .number(Float(num))
+            self = .number(Double(num))
         case let str as String:
             self = .string(str)
         case let bool as Bool:
@@ -78,7 +78,7 @@ extension JSON: ExpressibleByDictionaryLiteral {
 
 extension JSON: ExpressibleByFloatLiteral {
 
-    public init(floatLiteral value: Float) {
+    public init(floatLiteral value: Double) {
         self = .number(value)
     }
 }
@@ -86,7 +86,7 @@ extension JSON: ExpressibleByFloatLiteral {
 extension JSON: ExpressibleByIntegerLiteral {
 
     public init(integerLiteral value: Int) {
-        self = .number(Float(value))
+        self = .number(Double(value))
     }
 }
 

--- a/GenericJSON/JSON.swift
+++ b/GenericJSON/JSON.swift
@@ -6,7 +6,7 @@ import Foundation
 /// or strings.
 @dynamicMemberLookup public enum JSON: Equatable {
     case string(String)
-    case number(Float)
+    case number(Double)
     case object([String:JSON])
     case array([JSON])
     case bool(Bool)
@@ -47,7 +47,7 @@ extension JSON: Codable {
             self = .string(string)
         } else if let bool = try? container.decode(Bool.self) {
             self = .bool(bool)
-        } else if let number = try? container.decode(Float.self) {
+        } else if let number = try? container.decode(Double.self) {
             self = .number(number)
         } else if container.decodeNil() {
             self = .null

--- a/GenericJSON/Querying.swift
+++ b/GenericJSON/Querying.swift
@@ -10,8 +10,8 @@ public extension JSON {
         return nil
     }
 
-    /// Return the float value if this is a `.number`, otherwise `nil`
-    var floatValue: Float? {
+    /// Return the double value if this is a `.number`, otherwise `nil`
+    var doubleValue: Double? {
         if case .number(let value) = self {
             return value
         }

--- a/GenericJSONTests/InitializationTests.swift
+++ b/GenericJSONTests/InitializationTests.swift
@@ -8,7 +8,7 @@ class InitializationTests: XCTestCase {
         XCTAssertEqual(true as JSON, .bool(true))
         XCTAssertEqual([1, 2] as JSON, .array([.number(1), .number(2)]))
         XCTAssertEqual(["x": 1] as JSON, .object(["x": .number(1)]))
-        XCTAssertEqual(1.25 as JSON, .number(1.25))
+        XCTAssertEqual(3.4028236e+38 as JSON, .number(3.4028236e+38))
         XCTAssertEqual("foo" as JSON, .string("foo"))
     }
 

--- a/GenericJSONTests/InitializationTests.swift
+++ b/GenericJSONTests/InitializationTests.swift
@@ -53,4 +53,40 @@ class InitializationTests: XCTestCase {
             "b": true,
         ])
     }
+
+    func testInitializationFromJSONSerilization() throws {
+
+        let jsonData = """
+            {
+                "array": [
+                    1,
+                    2,
+                    3
+                ],
+                "boolean": true,
+                "null": null,
+                "number": 1,
+                "greatest_int": \(Int.max),
+                "greatest_double": \(Double.greatestFiniteMagnitude),
+                "object": {
+                    "a": "b"
+                },
+                "string": "Hello World"
+            }
+            """.data(using: .utf8)!
+
+        let jsonObject = try JSONSerialization.jsonObject(with: jsonData, options: [])
+        let json = try JSON(jsonObject)
+
+        XCTAssertEqual(JSON.array([1, 2, 3]), json["array"]!)
+        XCTAssertEqual(JSON.bool(true), json["boolean"]!)
+        XCTAssertEqual(JSON.number(1), json["number"]!)
+        XCTAssertEqual(JSON.number(Double(Int.max)), json["greatest_int"]!)
+        XCTAssertEqual(JSON.number(Double.greatestFiniteMagnitude), json["greatest_double"]!)
+        XCTAssertEqual(JSON.null, json["null"]!)
+        XCTAssertEqual(JSON.object(["a": "b"]), json["object"]!)
+        XCTAssertEqual(JSON.string("Hello World"), json["string"]!)
+
+    }
+
 }

--- a/GenericJSONTests/InitializationTests.swift
+++ b/GenericJSONTests/InitializationTests.swift
@@ -78,14 +78,14 @@ class InitializationTests: XCTestCase {
         let jsonObject = try JSONSerialization.jsonObject(with: jsonData, options: [])
         let json = try JSON(jsonObject)
 
-        XCTAssertEqual(JSON.array([1, 2, 3]), json["array"]!)
-        XCTAssertEqual(JSON.bool(true), json["boolean"]!)
-        XCTAssertEqual(JSON.number(1), json["number"]!)
-        XCTAssertEqual(JSON.number(Double(Int.max)), json["greatest_int"]!)
-        XCTAssertEqual(JSON.number(Double.greatestFiniteMagnitude), json["greatest_double"]!)
-        XCTAssertEqual(JSON.null, json["null"]!)
-        XCTAssertEqual(JSON.object(["a": "b"]), json["object"]!)
-        XCTAssertEqual(JSON.string("Hello World"), json["string"]!)
+        XCTAssertEqual(json["array"]!, JSON.array([1, 2, 3]))
+        XCTAssertEqual(json["boolean"]!, JSON.bool(true))
+        XCTAssertEqual(json["number"]!, JSON.number(1))
+        XCTAssertEqual(json["greatest_int"]!, JSON.number(Double(Int.max)))
+        XCTAssertEqual(json["greatest_double"]!, JSON.number(Double.greatestFiniteMagnitude))
+        XCTAssertEqual(json["null"]!, JSON.null)
+        XCTAssertEqual(json["object"]!, JSON.object(["a": "b"]))
+        XCTAssertEqual(json["string"]!, JSON.string("Hello World"))
 
     }
 

--- a/GenericJSONTests/QueryingTests.swift
+++ b/GenericJSONTests/QueryingTests.swift
@@ -10,9 +10,9 @@ class QueryingTests: XCTestCase {
     }
 
     func testFloatValue() {
-        XCTAssertEqual(JSON.number(42).floatValue, 42)
-        XCTAssertEqual(JSON.string("foo").floatValue, nil)
-        XCTAssertEqual(JSON.null.floatValue, nil)
+        XCTAssertEqual(JSON.number(42).doubleValue, 42)
+        XCTAssertEqual(JSON.string("foo").doubleValue, nil)
+        XCTAssertEqual(JSON.null.doubleValue, nil)
     }
 
     func testBoolValue() {


### PR DESCRIPTION
This PR fixes the issues described in [Issue 28](https://github.com/zoul/generic-json-swift/issues/28). Additionally, it replaces [PR 29](https://github.com/zoul/generic-json-swift/pull/29).

### Summary 

Adds support for:

1. `Double` numbers (64-bit floating point)
2. `NSNumber` initialization

To facilitate this, an extension on `NSNumber` and a few helper variables were added. Credit to the original source: [SwiftyJSON](https://github.com/SwiftyJSON/SwiftyJSON/blob/bad5f2f94a71216a32c030a3586bdcfc1f7e660b/Source/SwiftyJSON/SwiftyJSON.swift#L1228). Their license is MIT so this should be fine to include.

### Source Compatibility

This is a source *incompatible* change:

1. The `number` case on `JSON` has changed from `Float` to `Double`.
2. The computed property has been renamed from `floatValue`  to `doubleValue`.
   - Alternatively, the `floatValue` property can remain, and `doubleValue` simply added.

Let me know if there is anything you'd like to change.