### PR TITLE
Add Hashable conformance

### DIFF
--- a/GenericJSON/JSON.swift
+++ b/GenericJSON/JSON.swift
@@ -78,3 +78,5 @@ extension JSON: CustomDebugStringConvertible {
         }
     }
 }
+
+extension JSON: Hashable {}


### PR DESCRIPTION
This PR adds `Hashable` conformance for `JSON`. This is convenient when using JSON is sets, for example.

The only downside is the compiler will need to synthesise the conformance which may add a bit of overhead.