### PR TITLE
Support mutating JSON values

### DIFF
--- a/GenericJSONTests/CodingTests.swift
+++ b/GenericJSONTests/CodingTests.swift
@@ -22,13 +22,6 @@ class CodingTests: XCTestCase {
             """)
     }
 
-    func testFragmentEncoding() {
-        let fragments: [JSON] = ["foo", 1, true, nil]
-        for f in fragments {
-            XCTAssertThrowsError(try JSONEncoder().encode(f))
-        }
-    }
-
     func testDecoding() throws {
         let input = """
             {"array":[1],"num":1,"bool":true,"obj":{},"null":null,"str":"baz"}

--- a/GenericJSONTests/InitializationTests.swift
+++ b/GenericJSONTests/InitializationTests.swift
@@ -43,8 +43,8 @@ class InitializationTests: XCTestCase {
     func testInitializationFromCodable() throws {
 
         struct Foo: Codable {
-            let a: String = "foo"
-            let b: Bool = true
+            var a: String = "foo"
+            var b: Bool = true
         }
 
         let json = try JSON(encodable: Foo())

--- a/GenericJSONTests/QueryingTests.swift
+++ b/GenericJSONTests/QueryingTests.swift
@@ -3,42 +3,79 @@ import GenericJSON
 
 class QueryingTests: XCTestCase {
 
-    func testStringValue() {
+    func testGetStringValue() {
         XCTAssertEqual(JSON.string("foo").stringValue, "foo")
         XCTAssertEqual(JSON.number(42).stringValue, nil)
         XCTAssertEqual(JSON.null.stringValue, nil)
     }
 
-    func testFloatValue() {
+    func testSetStringValue() {
+        var value: JSON = "foo"
+        value = "bar"
+        XCTAssertEqual(value.stringValue, "bar")
+    }
+
+    func testGetFloatValue() {
         XCTAssertEqual(JSON.number(42).doubleValue, 42)
         XCTAssertEqual(JSON.string("foo").doubleValue, nil)
         XCTAssertEqual(JSON.null.doubleValue, nil)
     }
 
-    func testBoolValue() {
+    func testSetFloatValue() {
+        var value: JSON = 42
+        value = 43
+        XCTAssertEqual(value.doubleValue, 43)
+    }
+
+    func testGetBoolValue() {
         XCTAssertEqual(JSON.bool(true).boolValue, true)
         XCTAssertEqual(JSON.string("foo").boolValue, nil)
         XCTAssertEqual(JSON.null.boolValue, nil)
     }
 
-    func testObjectValue() {
+    func testSetBoolValue() {
+        var value: JSON = true
+        value = false
+        XCTAssertEqual(value, false)
+    }
+
+    func testGetObjectValue() {
         XCTAssertEqual(JSON.object(["foo": "bar"]).objectValue, ["foo": JSON.string("bar")])
         XCTAssertEqual(JSON.string("foo").objectValue, nil)
         XCTAssertEqual(JSON.null.objectValue, nil)
     }
 
-    func testArrayValue() {
+    func testSetObjectValue() {
+        var value: JSON = ["foo": "bar"]
+        value = ["foo": "baz"]
+        value["new"] = 42
+        XCTAssertEqual(value, ["foo": "baz", "new": JSON(42)])
+    }
+
+    func testGetArrayValue() {
         XCTAssertEqual(JSON.array(["foo", "bar"]).arrayValue, [JSON.string("foo"), JSON.string("bar")])
         XCTAssertEqual(JSON.string("foo").arrayValue, nil)
         XCTAssertEqual(JSON.null.arrayValue, nil)
     }
 
-    func testNullValue() {
+    func testSetArrayValue() {
+        var value: JSON = ["foo", "bar"]
+        value = ["baz"]
+        XCTAssertEqual(value, ["baz"])
+    }
+
+    func testGetNullValue() {
         XCTAssertEqual(JSON.null.isNull, true)
         XCTAssertEqual(JSON.string("foo").isNull, false)
     }
 
-    func testArraySubscripting() {
+    func testSetNullValue() {
+        var value: JSON = "foo"
+        value = nil
+        XCTAssertEqual(value, JSON.null)
+    }
+
+    func testGetArraySubscripting() {
         let json: JSON = ["foo", "bar"]
         XCTAssertEqual(json[0], JSON.string("foo"))
         XCTAssertEqual(json[-1], nil)
@@ -46,20 +83,50 @@ class QueryingTests: XCTestCase {
         XCTAssertEqual(json["foo"], nil)
     }
 
-    func testStringSubscripting() {
+    func testSetArraySubscripting() {
+        var value: JSON = ["foo", "bar"]
+        value[1] = "baz"
+        XCTAssertEqual(value, ["foo", "baz"])
+    }
+
+    func testGetStringSubscripting() {
         let json: JSON = ["foo": "bar"]
         XCTAssertEqual(json["foo"], JSON.string("bar"))
         XCTAssertEqual(json[0], nil)
         XCTAssertEqual(json["nonesuch"], nil)
     }
 
-    func testStringSubscriptingSugar() {
+    func testSetStringSubscripting() {
+        var json: JSON = ["foo": "bar"]
+        json["foo"] = "baz"
+        XCTAssertEqual(json, ["foo": "baz"])
+    }
+
+    func testSetStringSubscriptingNewValue() {
+        var json: JSON = ["foo": "bar"]
+        json["baz"] = 42
+        XCTAssertEqual(json, ["foo": "bar", "baz": JSON(42)])
+    }
+
+    func testGetStringSubscriptingSugar() {
         let json: JSON = ["foo": "bar"]
         XCTAssertEqual(json.foo, JSON.string("bar"))
         XCTAssertEqual(json.nonesuch, nil)
     }
+
+    func testSetStringSubscriptingSugar() {
+        var json: JSON = ["foo": "bar"]
+        json.foo = "baz"
+        XCTAssertEqual(json, ["foo": "baz"])
+    }
+
+    func testSetStringSubscriptingSugarNewValue() {
+        var json: JSON = ["foo": "bar"]
+        json.baz = 42
+        XCTAssertEqual(json, ["foo": "bar", "baz": JSON(42)])
+    }
     
-    func testKeyPath() {
+    func testGetKeyPath() {
         let json: JSON = [
             "string": "foo bar",
             "boolean": true,
@@ -80,5 +147,49 @@ class QueryingTests: XCTestCase {
         XCTAssertEqual(json[keyPath: "object.str"], "col")
         XCTAssertEqual(json[keyPath: "object.arr"], [1, 2, 3])
         XCTAssertEqual(json[keyPath: "object.obj.y"], "tar")
+    }
+
+    func testSetKeyPath() {
+        var json: JSON = [
+            "string": "foo bar",
+            "boolean": true,
+            "number": 123,
+            "object": [
+                "str": "col",
+                "arr": [1, 2, 3],
+                "obj": [
+                    "x": "rah",
+                    "y": "tar",
+                    "z": "yaz"
+                ]
+            ]
+        ]
+
+        json[keyPath: "boolean"] = false
+        XCTAssertEqual(json["boolean"], false)
+
+        json[keyPath: "string"] = "baz"
+        XCTAssertEqual(json.string, "baz")
+
+        json[keyPath: "number"] = 42
+        XCTAssertEqual(json["number"], 42)
+
+        json[keyPath: "object.str"] = "new"
+        XCTAssertEqual(json["object"]?["str"], "new")
+
+        json[keyPath: "object.arr"] = [42]
+        XCTAssertEqual(json["object"]?["arr"], [42])
+
+        json[keyPath: "object.obj.y"] = "new"
+        XCTAssertEqual(json["object"]?["obj"]?["y"], "new")
+    }
+
+    func testSetKeyPathNewValue() {
+        var json: JSON = [
+            "object": [:]
+        ]
+
+        json[keyPath: "object.new.new"] = 42
+        XCTAssertEqual(json["object"]?["new"]?["new"], 42)
     }
 }


### PR DESCRIPTION
Allow mutation of JSON object and its members:
```
func updateCost(data: Data) -> Data {
   var json = try JSONDecoder().decode(JSON.self, from: data)
   json["items"].arrayValue![3]["cost"] = 53
   return try JSONEncoder().encode(json)
}
```