### PR TITLE
Make JSON Sendable

### DIFF
--- a/GenericJSON/JSON.swift
+++ b/GenericJSON/JSON.swift
@@ -4,7 +4,7 @@ import Foundation
 /// for JSON values, since it makes sure only valid JSON values are present & supports `Equatable`
 /// and `Codable`, so that you can compare values for equality and code and decode them into data
 /// or strings.
-@dynamicMemberLookup public enum JSON: Equatable {
+@dynamicMemberLookup public enum JSON: Sendable, Equatable {
     case string(String)
     case number(Double)
     case object([String:JSON])

--- a/GenericJSON/JSON.swift
+++ b/GenericJSON/JSON.swift
@@ -4,7 +4,7 @@ import Foundation
 /// for JSON values, since it makes sure only valid JSON values are present & supports `Equatable`
 /// and `Codable`, so that you can compare values for equality and code and decode them into data
 /// or strings.
-@dynamicMemberLookup public enum JSON: Sendable, Equatable {
+@dynamicMemberLookup public enum JSON: Equatable {
     case string(String)
     case number(Double)
     case object([String:JSON])
@@ -12,6 +12,10 @@ import Foundation
     case bool(Bool)
     case null
 }
+
+#if swift(>=5.5)
+extension JSON : Sendable{}
+#endif
 
 extension JSON: Codable {
 

--- a/GenericJSONTests/InitializationTests.swift
+++ b/GenericJSONTests/InitializationTests.swift
@@ -17,7 +17,7 @@ class InitializationTests: XCTestCase {
         let bool = true
         let str = "foo"
         let json = try JSON([
-            "a": [num, bool],
+            "a": [num, bool] as [Any],
             "b": [str, [str], [str: bool]],
         ])
         XCTAssertEqual(json, [


### PR DESCRIPTION
Sendability is getting more and more present in Swift.
This PR adds conformance to the `Sendable` protocol to `JSON` when the compiler version is `>=5.5`. There is nothing else to do AFAICT as `JSON` was already `Sendable`.